### PR TITLE
Process independant tmp dirs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,4 +14,4 @@ python3 test.py [PLAYLIST_URL]
 - [ ] other (specify below):
 
 ## Details:
-Be sure to include links relevent issues if applicable.
+Be sure to include links relevant issues if applicable.

--- a/sync_dl/__init__.py
+++ b/sync_dl/__init__.py
@@ -3,7 +3,7 @@ from threading import current_thread
 from sync_dl import config as cfg
 from signal import signal, SIGINT, Signals#,SIGABRT,SIGTERM
 
-__version__ = "2.3.0"
+__version__ = "2.3.1"
 
 class InterruptTriggered(Exception):
     pass

--- a/sync_dl/config.py
+++ b/sync_dl/config.py
@@ -1,4 +1,5 @@
 import configparser
+from tempfile import TemporaryDirectory
 import os
 from re import compile
 from ntpath import dirname
@@ -52,6 +53,7 @@ def _getConfig():
 
 
 _config = _getConfig()
+_tmpDir = TemporaryDirectory()
 
 # global config variables
 filePrependRE = compile(r'\d+_')
@@ -62,7 +64,7 @@ knownFormats = FFmpegExtractAudioPP.SUPPORTED_EXTS
 metaDataName = _config['metaDataName']
 manualAddId =_config['manualAddId']
 testPlPath = f"{modulePath}/{_config['testPlPath']}" 
-tmpDownloadPath = f"{modulePath}/{_config['tmpDownloadPath']}"
+tmpDownloadPath = _tmpDir.name#f"{modulePath}/{_config['tmpDownloadPath']}"
 musicDir = _config['musicDir']
 ffmpegMetadataPath = f'{tmpDownloadPath}/FFMETADATAFILE'
 songSegmentsPath = f'{tmpDownloadPath}/songSegmants'

--- a/sync_dl/config.py
+++ b/sync_dl/config.py
@@ -26,7 +26,6 @@ def _getConfig():
         'metaDataName' : '.metaData',
         'manualAddId' : '-manualAddition',
         'testPlPath' : 'tests/testPlaylists',
-        'tmpDownloadPath' : 'tmp',
         'musicDir' : '',
         'autoScrapeCommentTimestamps': '0',
         'audioFormat': 'best',
@@ -64,7 +63,7 @@ knownFormats = FFmpegExtractAudioPP.SUPPORTED_EXTS
 metaDataName = _config['metaDataName']
 manualAddId =_config['manualAddId']
 testPlPath = f"{modulePath}/{_config['testPlPath']}" 
-tmpDownloadPath = _tmpDir.name#f"{modulePath}/{_config['tmpDownloadPath']}"
+tmpDownloadPath = _tmpDir.name
 musicDir = _config['musicDir']
 ffmpegMetadataPath = f'{tmpDownloadPath}/FFMETADATAFILE'
 songSegmentsPath = f'{tmpDownloadPath}/songSegmants'

--- a/sync_dl/timestamps/timestamps.py
+++ b/sync_dl/timestamps/timestamps.py
@@ -1,6 +1,7 @@
 import re
 import os
 import subprocess
+import shutil
 
 import sync_dl.config as cfg
 from sync_dl.timestamps.scraping import Timestamp
@@ -104,6 +105,6 @@ def applyChapterFileToSong(songPath:str, songName:str) -> bool:
         return False
 
     with noInterrupt:
-        os.replace(f"{cfg.tmpDownloadPath}/{songName}", songPath)
+        shutil.move(f"{cfg.tmpDownloadPath}/{songName}", songPath)
     return True
 


### PR DESCRIPTION
# Pull Request

## This pull request is for: 
- [x] bug fix
- [ ] new feature
- [ ] improvement
- [ ] other (specify below):

## Details:
unique tmp file is created on process start to allow for multiple instances of sync-dl to run in parallel (note multiple instances of sync-dl should not be ran on the same playlist simultaneously)

Fixes #7 